### PR TITLE
add stl header for string conversion with gcc

### DIFF
--- a/c++/h5/stl/vector.cpp
+++ b/c++/h5/stl/vector.cpp
@@ -3,6 +3,7 @@
 #include <hdf5_hl.h>
 #include <array>
 #include <cstring>
+#include <algorithm> 
 
 #include "./string.hpp"
 


### PR DESCRIPTION
Hi,

I was trying to compile the code on the cluster machines using just gcc 9.4.0 and the gcc standard library. I got the error 

```
/mnt/home/pdumitrescu/Documents/coding/repos/kryqup/build/deps/h5_src/c++/h5/stl/vector.cpp:65:32: error: cannot convert 'std::__cxx11::basic_string<char>::iterator' {aka '__gnu_cxx::__normal_iterator<char*, std::__cxx11::basic_string<char> >'} to 'const char*'
   65 |       x.erase(std::remove(begin(x), end(x), '\0'), end(x));
      |                           ~~~~~^~~
      |                                |
      |                                std::__cxx11::basic_string<char>::iterator {aka __gnu_cxx::__normal_iterator<char*, std::__cxx11::basic_string<char> >}
In file included from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/cstdio:42,
                 from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/ext/string_conversions.h:43,
                 from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/bits/basic_string.h:6493,
                 from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/string:55,
                 from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/bits/locale_classes.h:40,
                 from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/bits/ios_base.h:41,
                 from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/ios:42,
                 from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/istream:38,
                 from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/sstream:38,
                 from /cm/shared/sw/pkg/devel/gcc/9.3.0/include/c++/9.3.0/complex:45,
                 from /mnt/home/pdumitrescu/Documents/coding/repos/kryqup/build/deps/h5_src/c++/h5/stl/./vector.hpp:3,
                 from /mnt/home/pdumitrescu/Documents/coding/repos/kryqup/build/deps/h5_src/c++/h5/stl/vector.cpp:1:
```

I fixed this by adding the stl algorithm header, which solved this issue.

(In my experience gcc is less forgiving there than clang).

See also a similar issue in cpp2py. 

Thanks! 