### PR TITLE
Add std::array h5_read/h5_write + test

### DIFF
--- a/c++/h5/array_interface.cpp
+++ b/c++/h5/array_interface.cpp
@@ -5,6 +5,7 @@
 #include <hdf5_hl.h>
 
 #include <numeric>
+#include <algorithm>
 #include <iostream> // DEBUG
 
 namespace h5::array_interface {
@@ -128,7 +129,7 @@ namespace h5::array_interface {
     dataspace file_d_space = H5Dget_space(ds);
 
     // Checks
-    if (H5Tequal(v.ty, lt.ty) <= 0)
+    if (not hdf5_type_equal(v.ty, lt.ty))
       throw std::runtime_error("h5 read. Type mismatch : expecting a " + get_name_of_h5_type(v.ty)
                                + " while the array stored in the hdf5 file has type " + get_name_of_h5_type(lt.ty));
 
@@ -136,14 +137,12 @@ namespace h5::array_interface {
       throw std::runtime_error("h5 read. Rank mismatch : expecting in file a rank " + std::to_string(v.rank())
                                + " while the array stored in the hdf5 file has rank " + std::to_string(lt.rank()));
 
-    //if (lt.lengths != v.slab.count)
-    //throw std::runtime_error("h5 read. Lengths mismatch : expecting a rank " + std::to_string(v.rank())
-    //+ " while the array stored in the hdf5 file has rank = " + std::to_string(lt.rank()));
+    if (lt.lengths != v.slab.count) throw std::runtime_error("h5 read. Lengths mismatch");
 
     dataspace mem_d_space = make_mem_dpace(v);
     if (H5Sget_simple_extent_npoints(file_d_space) > 0) {
       herr_t err = H5Dread(ds, v.ty, mem_d_space, file_d_space, H5P_DEFAULT, v.start);
-      if (err < 0) throw std::runtime_error("Error reading the scalar dataset " + name + " in the group" + g.name());
+      if (err < 0) throw std::runtime_error("Error reading the scalar dataset " + name + " in the group " + g.name());
     }
   }
 

--- a/c++/h5/h5.hpp
+++ b/c++/h5/h5.hpp
@@ -7,6 +7,7 @@
 #include "./format.hpp"
 #include "./scalar.hpp"
 #include "./stl/string.hpp"
+#include "./stl/array.hpp"
 #include "./stl/vector.hpp"
 #include "./stl/map.hpp"
 #include "./stl/pair.hpp"

--- a/c++/h5/stl/array.hpp
+++ b/c++/h5/stl/array.hpp
@@ -1,0 +1,103 @@
+#pragma once
+#include "../array_interface.hpp"
+
+#include <array>
+#include <algorithm>
+#include <type_traits>
+
+namespace h5 {
+
+  /**
+   * Writes std::array into an hdf5 file
+   *
+   * @tparam T
+   * @param g HDF5 group
+   * @param name Name of the object in the HDF5 file
+   * @param a Array to save in the file
+   */
+  template <typename T, size_t N>
+  void h5_write(group g, std::string const &name, std::array<T, N> const &a) {
+
+    if constexpr (std::is_same_v<T, std::string>) {
+      auto char_arr = std::array<const char *, N>{};
+      std::transform(cbegin(a), cend(a), begin(char_arr), [](std::string const &s) { return s.c_str(); });
+      h5_write(g, name, char_arr);
+
+    } else if constexpr (std::is_arithmetic_v<T> or is_complex_v<T> or std::is_same_v<T, char *> or std::is_same_v<T, const char *>) {
+
+      static constexpr bool is_complex = is_complex_v<T>;
+
+      h5::array_interface::h5_array_view v{hdf5_type<T>(), (void *)a.data(), 1, is_complex};
+      v.slab.count[0]  = N;
+      v.slab.stride[0] = 1;
+      v.L_tot[0]       = N;
+
+      h5::array_interface::write(g, name, v, true);
+
+    } else { // generic unknown type to hdf5
+      auto g2 = g.create_group(name);
+      h5_write(g2, "shape", std::array<long, 1>{N});
+      for (int i = 0; i < N; ++i) h5_write(g2, std::to_string(i), a[i]);
+    }
+  }
+
+  /**
+   * Reads std::array from HDF5
+   *
+   * Use implementation h5_read from the array_interface
+   *
+   * @tparam T
+   * @param g HDF5 group
+   * @param name Name of the object in the HDF5 file
+   * @param a Array to save from the file
+   */
+  template <typename T, size_t N>
+  void h5_read(group g, std::string name, std::array<T, N> &a) {
+
+    if constexpr (std::is_same_v<T, std::string>) {
+      auto char_arr = std::array<char *, N>{};
+      h5_read(g, name, char_arr);
+      std::copy(cbegin(char_arr), cend(char_arr), begin(a));
+      std::for_each(begin(char_arr), end(char_arr), [](char *cb) { delete cb; });
+
+    } else if constexpr (std::is_arithmetic_v<T> or is_complex_v<T> or std::is_same_v<T, char *> or std::is_same_v<T, const char *>) {
+
+      static constexpr bool is_complex = is_complex_v<T>;
+
+      auto lt = array_interface::get_h5_lengths_type(g, name);
+
+      // Allow to read non-complex data into array<complex>
+      if constexpr (is_complex) {
+        if (!lt.has_complex_attribute) {
+          std::array<double, N> tmp;
+          h5_read(g, name, tmp);
+          a = tmp;
+          return;
+        }
+      }
+
+      int rank_in_file = lt.rank() - (is_complex ? 1 : 0);
+      H5_EXPECTS(rank_in_file == 1);
+      H5_EXPECTS(N == lt.lengths[0]);
+
+      array_interface::h5_array_view v{hdf5_type<T>(), (void *)(a.data()), 1, is_complex};
+      v.slab.count[0]  = N;
+      v.slab.stride[0] = 1;
+      v.L_tot[0]       = N;
+
+      array_interface::read(g, name, v, lt);
+
+    } else { // generic unknown type to hdf5
+      auto g2 = g.open_group(name);
+
+      // Check that shapes are compatible
+      auto h5_shape = std::array<long, 1>{};
+      h5_read(g2, "shape", h5_shape);
+      H5_EXPECTS(N == h5_shape[0]);
+
+      // Read using appropriate h5_read implementation
+      for (int i = 0; i < N; ++i) h5_read(g2, std::to_string(i), a[i]);
+    }
+  }
+
+} // namespace h5

--- a/test/c++/h5_array.cpp
+++ b/test/c++/h5_array.cpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *
+ * H5: a Toolbox for Research in Interacting Quantum Systems
+ *
+ * Copyright (C) 2020 Simons Foundation
+ *    author: N. Wentzell
+ *
+ * H5 is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * H5 is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * H5. If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#include "./test_common.hpp"
+
+#include <h5/h5.hpp>
+#include <array>
+#include <string>
+
+TEST(H5, Array) {
+
+  // write
+  auto arr_str = std::array<std::string, 2>{"a", "abc"};
+  auto arr_dbl = std::array<double, 2>{1.0, 2.0};
+
+  {
+    h5::file file{"test_arr.h5", 'w'};
+    h5::group grp{file};
+    h5_write(grp, "arr_str", arr_str);
+    h5_write(grp, "arr_dbl", arr_dbl);
+  }
+
+  // read
+  std::array<std::string, 2> arr_str_r;
+  std::array<double, 2> arr_dbl_r;
+
+  {
+    h5::file file{"test_arr.h5", 'r'};
+    h5::group grp{file};
+    h5_read(grp, "arr_str", arr_str_r);
+    h5_read(grp, "arr_dbl", arr_dbl_r);
+  }
+
+  // compare
+  EXPECT_EQ(arr_str, arr_str_r);
+  EXPECT_EQ(arr_dbl, arr_dbl_r);
+}


### PR DESCRIPTION
-array<string> will go through array<char *> without use of charbuf