### PR TITLE
Allowed custom key class in reading/writing of a map.

### DIFF
--- a/c++/h5/stl/map.hpp
+++ b/c++/h5/stl/map.hpp
@@ -55,22 +55,19 @@ namespace h5 {
     auto gr = f.open_group(name);
     M.clear();
     
-    if constexpr (std::is_same_v<keyT, std::string>){
-      for (auto const &x : gr.get_all_subgroup_dataset_names()) {
+    for (auto const &x : gr.get_all_subgroup_dataset_names()) {
         valueT value;
-        h5_read(gr, x, value);
-        M.emplace(x, std::move(value));
-      }
-    }
-    else {
-      for (auto const &x : gr.get_all_subgroup_dataset_names()) {
-        auto element_gr = gr.open_group(x);
-        keyT key;
-        valueT value;
-        h5_read(element_gr, "key", key);
-        h5_read(element_gr, "val", value);
-        M.emplace(std::move(key), std::move(value));
-      }
+        if constexpr (std::is_same_v<keyT, std::string>){
+          h5_read(gr, x, value);
+          M.emplace(x, std::move(value));
+        }
+        else{
+          auto element_gr = gr.open_group(x);
+          keyT key;
+          h5_read(element_gr, "key", key);
+          h5_read(element_gr, "val", value);
+          M.emplace(std::move(key), std::move(value));
+        }
     }
   }
 

--- a/c++/h5/stl/map.hpp
+++ b/c++/h5/stl/map.hpp
@@ -74,27 +74,5 @@ namespace h5 {
     }
   }
 
-  /*
-  template <typename T>
-  void h5_write(group f, std::string const &name, std::map<std::string, T> const &M) {
-    auto gr = f.create_group(name);
-    write_hdf5_format(gr, M);
-    
-    for (auto &pvp : M) h5_write(gr, pvp.first, pvp.second);
-  }
-
-  template <typename T>
-  void h5_read(group f, std::string const &name, std::map<std::string, T> &M) {
-    auto gr = f.open_group(name);
-    M.clear();
-    
-    for (auto const &x : gr.get_all_subgroup_dataset_names()) {
-      T value;
-      h5_read(gr, x, value);
-      M.emplace(x, std::move(value));
-    }
-
-  }*/
-
 
 } // namespace h5

--- a/c++/h5/stl/map.hpp
+++ b/c++/h5/stl/map.hpp
@@ -56,17 +56,17 @@ namespace h5 {
     M.clear();
     
     for (auto const &x : gr.get_all_subgroup_dataset_names()) {
-        valueT value;
+        valueT val;
         if constexpr (std::is_same_v<keyT, std::string>){
-          h5_read(gr, x, value);
-          M.emplace(x, std::move(value));
+          h5_read(gr, x, val);
+          M.emplace(x, std::move(val));
         }
         else{
           auto element_gr = gr.open_group(x);
           keyT key;
           h5_read(element_gr, "key", key);
-          h5_read(element_gr, "val", value);
-          M.emplace(std::move(key), std::move(value));
+          h5_read(element_gr, "val", val);
+          M.emplace(std::move(key), std::move(val));
         }
     }
   }

--- a/c++/h5/stl/map.hpp
+++ b/c++/h5/stl/map.hpp
@@ -41,10 +41,10 @@ namespace h5 {
     }
     else {
       int indx = 0;
-      for (auto &pvp : M) {
-        auto element_gr = gr.create_group( std::to_string(indx) );
-        h5_write(element_gr, "key", pvp.first);
-        h5_write(element_gr, "val", pvp.second);
+      for (auto const &[key, val] : M) {
+        auto element_gr = gr.create_group(std::to_string(indx));
+        h5_write(element_gr, "key", key);
+        h5_write(element_gr, "val", val);
         ++indx;
       }
     }

--- a/c++/h5/stl/map.hpp
+++ b/c++/h5/stl/map.hpp
@@ -37,7 +37,7 @@ namespace h5 {
     write_hdf5_format(gr, M);
     
     if constexpr (std::is_same_v<keyT, std::string>){
-      for (auto &pvp : M) h5_write(gr, pvp.first, pvp.second);
+      for (auto const &[key, val] : M) h5_write(gr, key, val);
     }
     else {
       int indx = 0;

--- a/c++/h5/stl/map.hpp
+++ b/c++/h5/stl/map.hpp
@@ -69,7 +69,7 @@ namespace h5 {
         valueT value;
         h5_read(element_gr, "key", key);
         h5_read(element_gr, "val", value);
-        M.emplace(key, std::move(value));
+        M.emplace(std::move(key), std::move(value));
       }
     }
   }

--- a/c++/h5/stl/map.hpp
+++ b/c++/h5/stl/map.hpp
@@ -14,38 +14,87 @@
 
 #pragma once
 #include <map>
+#include <type_traits>
 #include "../group.hpp"
 #include "./string.hpp"
 
 namespace h5 {
 
-  template <typename T>
-  struct hdf5_format_impl<std::map<std::string, T>> {
+  template <typename keyT, typename valueT>
+  struct hdf5_format_impl<std::map<keyT, valueT>> {
     static std::string invoke() { return "Dict"; }
   };
 
+
   /**
-   * Map of string and T as a subgroup with key_names
-   */
+   * Map of type keyT for the key and valueT for the value. keyT can be any 
+   * class as long as it is writeable to h5 (an operator "<" is needed to 
+   * be used in a map in the first place).
+  */
+  template <typename keyT, typename valueT>
+  void h5_write(group f, std::string const &name, std::map<keyT, valueT> const &M) {
+    auto gr = f.create_group(name);
+    write_hdf5_format(gr, M);
+    
+    if constexpr (std::is_same_v<keyT, std::string>){
+      for (auto &pvp : M) h5_write(gr, pvp.first, pvp.second);
+    }
+    else {
+      int indx = 0;
+      for (auto &pvp : M) {
+        auto element_gr = gr.create_group( std::to_string(indx) );
+        h5_write(element_gr, "key", pvp.first);
+        h5_write(element_gr, "val", pvp.second);
+        ++indx;
+      }
+    }
+  }
+
+  template <typename keyT, typename valueT>
+  void h5_read(group f, std::string const &name, std::map<keyT, valueT> &M) {
+    auto gr = f.open_group(name);
+    M.clear();
+    
+    if constexpr (std::is_same_v<keyT, std::string>){
+      for (auto const &x : gr.get_all_subgroup_dataset_names()) {
+        valueT value;
+        h5_read(gr, x, value);
+        M.emplace(x, std::move(value));
+      }
+    }
+    else {
+      for (auto const &x : gr.get_all_subgroup_dataset_names()) {
+        auto element_gr = gr.open_group(x);
+        keyT key;
+        valueT value;
+        h5_read(element_gr, "key", key);
+        h5_read(element_gr, "val", value);
+        M.emplace(key, std::move(value));
+      }
+    }
+  }
+
+  /*
   template <typename T>
   void h5_write(group f, std::string const &name, std::map<std::string, T> const &M) {
     auto gr = f.create_group(name);
     write_hdf5_format(gr, M);
+    
     for (auto &pvp : M) h5_write(gr, pvp.first, pvp.second);
   }
 
-  /**
-   * Map of string and T
-   */
   template <typename T>
   void h5_read(group f, std::string const &name, std::map<std::string, T> &M) {
     auto gr = f.open_group(name);
     M.clear();
+    
     for (auto const &x : gr.get_all_subgroup_dataset_names()) {
       T value;
       h5_read(gr, x, value);
       M.emplace(x, std::move(value));
     }
-  }
+
+  }*/
+
 
 } // namespace h5

--- a/test/c++/h5_map.cpp
+++ b/test/c++/h5_map.cpp
@@ -45,3 +45,99 @@ TEST(H5, Map) {
   EXPECT_EQ(m, mm);
   EXPECT_EQ(mv, mmv);
 }
+
+
+
+
+class custom_key_class {
+  
+  int var;
+  
+  public: 
+  custom_key_class(int v = 0): var(v){};
+
+  static std::string hdf5_format() { return "TestkeyClass"; }
+
+  friend void h5_write(h5::group f, std::string const &name, custom_key_class const &c){
+    h5_write(f, name,  c.var );
+  };
+
+  friend void h5_read(h5::group f, std::string const &name, custom_key_class &c){
+    h5_read(f, name,  c.var );
+  };
+
+  bool operator < (const custom_key_class& other) const{
+    return var < other.var;
+  }
+  
+  bool operator == (const custom_key_class& other) const{
+    return var == other.var;
+  }
+};
+
+TEST(H5, Map_customKey) {
+  // Read/Write with custom key.
+
+  // write
+  std::map<custom_key_class, std::string> m;
+  m.emplace(custom_key_class(1), "hey");
+  m.emplace(custom_key_class(10),"you");
+
+  {
+    h5::file file{"test_map_2.h5", 'w'};
+    h5::group grp{file};
+    h5_write(grp, "map_customClass", m);
+  }
+
+  // read
+  std::map<custom_key_class, std::string> mm;
+  {
+    h5::file file{"test_map_2.h5", 'r'};
+    h5::group grp{file};
+    h5_read(grp, "map_customClass", mm);
+  }
+
+  // compare
+  EXPECT_EQ(m, mm);
+}
+
+
+
+
+
+template <typename T>
+void h5_write_old(h5::group f, std::string const &name, std::map<std::string, T> const &M) {
+  auto gr = f.create_group(name);
+  write_hdf5_format(gr, M);
+  
+  for (auto &pvp : M) h5_write(gr, pvp.first, pvp.second);
+}
+
+
+TEST(H5, Map_OldVsNew) {
+  // Tests backwards compatibility by writing with the old function and reading
+  // using the new function.
+
+  // write
+  std::map<std::string, int> m;
+  m.emplace("hey",1);
+  m.emplace("you",15);
+
+  {
+    h5::file file{"test_map_3.h5", 'w'};
+    h5::group grp{file};
+    h5_write_old(grp, "map_int", m);
+  }
+
+  // read
+  std::map<std::string, int> mm;
+  {
+    h5::file file{"test_map_3.h5", 'r'};
+    h5::group grp{file};
+    h5_read(grp, "map_int", mm);
+  }
+
+  // compare
+  EXPECT_EQ(m, mm);
+}
+


### PR DESCRIPTION
String keys are written/read the exact same way as before ensuring backwards compatibility. This is also explicitly tested in one of the new tests which uses the old function for writing but the new one for reading. Feel free to delete this test if you think it is unnecessary, its purpose is to demonstrate that I tried to make sure that everything still works.

The other new test also serves as a template what needs to be implemented in a custom key class.


Best Daniel