### PR TITLE
Adjustable compression level for groups

### DIFF
--- a/c++/h5/array_interface.hpp
+++ b/c++/h5/array_interface.hpp
@@ -85,7 +85,7 @@ namespace h5::array_interface {
   h5_lengths_type get_h5_lengths_type(group g, std::string const &name);
 
   // Write the view of the array to the group
-  void write(group g, std::string const &name, h5_array_view const &a, bool compress);
+  void write(group g, std::string const &name, h5_array_view const &a, std::size_t compress_level);
 
   // Read into an array_view from the group
   void read(group g, std::string const &name, h5_array_view v, h5_lengths_type lt);

--- a/c++/h5/group.hpp
+++ b/c++/h5/group.hpp
@@ -25,12 +25,14 @@ namespace h5 {
   class group : public object {
 
     file parent_file;
+    std::size_t compress_level;
 
     public:
     group() = default; // for python converter only
 
     /// Takes the "/" group at the top of the file
     group(file f);
+    group(file f, std::size_t compress_level);
 
     ///
     group(group const &) = default;
@@ -38,7 +40,11 @@ namespace h5 {
     private:
     // construct from the bare object and the parent
     // internal use only for open/create subgroup
-    group(object obj, file _parent_file) : object{obj}, parent_file(std::move(_parent_file)) {}
+    group(object obj, file _parent_file, std::size_t _compress_level)
+        : object{obj}
+        , parent_file(std::move(_parent_file))
+        , compress_level{_compress_level}
+    {}
 
     public:
     /// Name of the group
@@ -46,6 +52,9 @@ namespace h5 {
 
     /// Access to the parent file
     [[nodiscard]] file get_file() const { return parent_file; }
+
+    /// Access to the compression level
+    [[nodiscard]] std::size_t get_compress_level() const { return compress_level; }
 
     /**
      * True iff key is an object in the group

--- a/c++/h5/scalar.hpp
+++ b/c++/h5/scalar.hpp
@@ -27,7 +27,7 @@ namespace h5 {
 
   template <typename T>
   void h5_write(group g, std::string const &name, T const &x) H5_REQUIRES(std::is_arithmetic_v<T> or is_complex_v<T> or std::is_same_v<T, dcplx_t>) {
-    array_interface::write(g, name, array_interface::h5_array_view_from_scalar(x), false);
+    array_interface::write(g, name, array_interface::h5_array_view_from_scalar(x), 0);
   }
 
   template <typename T>

--- a/c++/h5/stl/array.hpp
+++ b/c++/h5/stl/array.hpp
@@ -45,7 +45,7 @@ namespace h5 {
       v.slab.stride[0] = 1;
       v.L_tot[0]       = N;
 
-      h5::array_interface::write(g, name, v, true);
+      h5::array_interface::write(g, name, v, g.get_compress_level());
 
     } else { // generic unknown type to hdf5
       auto g2 = g.create_group(name);

--- a/c++/h5/stl/vector.hpp
+++ b/c++/h5/stl/vector.hpp
@@ -73,7 +73,7 @@ namespace h5 {
 
     if constexpr (std::is_arithmetic_v<T> or is_complex_v<T>) {
 
-      array_interface::write(g, name, array_interface::h5_array_view_from_vector(v), true);
+      array_interface::write(g, name, array_interface::h5_array_view_from_vector(v), g.get_compress_level());
 
     } else if constexpr (std::is_same_v<T, std::string> or std::is_same_v<T, std::vector<std::string>>) {
 

--- a/python/h5/_h5py_desc.py
+++ b/python/h5/_h5py_desc.py
@@ -49,6 +49,7 @@ c = class_(
 )
 
 c.add_constructor("""(file f)""", doc = r"""Takes the "/" group at the top of the file""")
+c.add_constructor("""(file f, std::size_t compress_level)""", doc = r"""Takes the "/" group at the top of the file""")
 
 c.add_property(name = "name", getter = cfunction("""std::string name ()"""),
              doc = r"""Name of the group""")

--- a/python/h5/archive.py
+++ b/python/h5/archive.py
@@ -302,7 +302,7 @@ class HDFArchive(HDFArchiveGroup):
     _class_version = 1
 
     def __init__(self, url_name, open_flag = 'a', key_as_string_only = True,
-            reconstruct_python_object = True, init = {}):
+            reconstruct_python_object = True, init = {}, compress_level = 1):
         r"""
            Parameters
            -----------
@@ -366,7 +366,7 @@ class HDFArchive(HDFArchiveGroup):
             try: os.remove(os.path.abspath(LocalFileName))
             except OSError: pass
 
-        self._init_root(LocalFileName, open_flag)
+        self._init_root(LocalFileName, open_flag, compress_level)
         self.options = {'key_as_string_only' : key_as_string_only,
                         'do_not_overwrite_entries' : False,
                         'reconstruct_python_object': reconstruct_python_object,

--- a/python/h5/archive_basic_layer.py
+++ b/python/h5/archive_basic_layer.py
@@ -27,7 +27,7 @@ class HDFArchiveGroupBasicLayer:
         self.ignored_keys = [] 
         self.cached_keys = list(self._group.keys())
 
-    def _init_root(self, LocalFileName, open_flag) :
+    def _init_root(self, LocalFileName, open_flag, compress_level) :
         try :
             fich = h5.File(LocalFileName, open_flag)
         except :
@@ -43,7 +43,7 @@ class HDFArchiveGroupBasicLayer:
                 self._version = 1
             if self._version > self._class_version :
                 raise IOError("File %s is too recent for this version of HDFArchive module"%Filename)
-        self._group = h5.Group(fich)
+        self._group = h5.Group(fich, compress_level)
 
     def is_group(self,p) :
         """Is p a subgroup ?"""

--- a/python/h5/h5py_io.cpp
+++ b/python/h5/h5py_io.cpp
@@ -180,7 +180,7 @@ namespace h5 {
 
     if (PyArray_Check(ob)) {
       PyArrayObject *arr_obj = (PyArrayObject *)ob;
-      write(g, name, make_av_from_npy(arr_obj), true);
+      write(g, name, make_av_from_npy(arr_obj), g.get_compress_level());
     } else if (PyArray_CheckScalar(ob)) {
       // Treat numpy scalars as 0-dimensional ndarrays
       cpp2py::pyref obsc = PyArray_FromScalar(ob, NULL);


### PR DESCRIPTION
The deflate compression of HDF5 supports multiple levels (0-9) but currently only level 1 is being used for array data.  Only applying compression for array data is reasonable but sometimes I wish a higher level could be chosen, especially when there are quantities that are mostly zero.  This PR makes the compression level adjustable on group creation and adds a few assertions to ensure that a valid value is chosen.

Unfortunately, at this point the compression level does not round-trip through the file, i.e. when loading a dataset and inspecting the compression level it is the one that the group was created with (default: 1) and not the one from the file.  However, it seems that currently no filter information is read from the HDF5 file at all, so I left it at that.

https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetDeflate
