### PR TITLE
Allow creation of softlinks

### DIFF
--- a/c++/h5/group.cpp
+++ b/c++/h5/group.cpp
@@ -95,6 +95,15 @@ namespace h5 {
     return group(obj, parent_file);
   }
 
+  void group::create_softlink(std::string const &target_key, std::string const& key, bool delete_if_exists) const {
+    if (target_key.empty() || key.empty()) return;
+    if (!has_key(target_key)) throw std::runtime_error("The target key " + target_key + " does not exist in group " + name());
+    if (delete_if_exists) unlink(key, false);
+    else if (has_key(key)) throw std::runtime_error("The key " + key + " already exists in group " + name());
+    auto const err = H5Lcreate_soft(target_key.c_str(), id, key.c_str(), H5P_DEFAULT, H5P_DEFAULT);
+    if (err < 0) throw std::runtime_error("Cannot create softlink " + target_key + " <- " + key);
+  }
+
   /// Open an existing DataSet. Throw if it does not exist.
   dataset group::open_dataset(std::string const &key) const {
     if (!has_key(key)) throw std::runtime_error("no dataset " + key + " in the group");

--- a/c++/h5/group.hpp
+++ b/c++/h5/group.hpp
@@ -98,6 +98,15 @@ namespace h5 {
     group create_group(std::string const &key, bool delete_if_exists = true) const; // NOLINT
 
     /**
+     * Create a softlink in this group
+     * 
+     * @param target_key  The path the link should point to. Has to exist.
+     * @param key  The link name that will point to the target path.
+     * @param delete_if_exists  Unlink the key first if it exists.
+     */
+    void create_softlink(std::string const &target_key, std::string const &key, bool delete_if_exists = true) const;
+
+    /**
      * Open a existing DataSet in the group.
      * Throws std::runtime_error if it does not exist.
      *

--- a/python/h5/_h5py.cpp
+++ b/python/h5/_h5py.cpp
@@ -30,6 +30,7 @@ PYBIND11_MODULE(_h5py, m) {
      .def(py::init<h5::file>(), "Constructor", "f"_a)
      .def_property_readonly("name", &h5::group::name, "Name of the group")
      .def("open_group", &h5::group::open_group, "Open the subgroup", "key"_a)
+     .def("create_softlink", &h5::group::create_softlink, "Create a softlink", "target_key"_a, "key"_a, "delete_if_exists"_a = true)
      .def("create_group", &h5::group::create_group, "Open the subgroup", "key"_a, "delete_if_exists"_a = true)
      .def("keys", &h5::group::get_all_subgroup_dataset_names, "All the keys")
      .def("has_subgroup", &h5::group::has_subgroup, "", "key"_a)

--- a/python/h5/_h5py_desc.py
+++ b/python/h5/_h5py_desc.py
@@ -80,6 +80,20 @@ key
 delete_if_exists
      Unlink the group if it exists""")
 
+c.add_method("""void create_softlink (std::string target_key, std::string key, bool delete_if_exists = true)""",
+             doc = r"""Create a softlink
+
+Parameters
+----------
+target_key
+     The path the link should point to. Has to exist.
+
+key
+     The link name that will point to the target path.
+
+delete_if_exists
+     Unlink the key first if it exists.""")
+
 c.add_method("""std::vector<std::string> get_all_subgroup_dataset_names ()""", name='keys',
              doc = r"""Returns all names of dataset of G""")
 

--- a/python/h5/archive_basic_layer.py
+++ b/python/h5/archive_basic_layer.py
@@ -86,6 +86,10 @@ class HDFArchiveGroupBasicLayer:
         self._group.create_group(key)
         self.cached_keys.append(key)
 
+    def create_softlink (self,target_key,key,delete_if_exists=True):
+        self._group.create_softlink(target_key,key,delete_if_exists)
+        self.cached_keys.append(key)
+
     def keys(self) :
         return self.cached_keys
 


### PR DESCRIPTION
This feature is quite useful for having a link in the output archive that always points to the last iteration of the calculation.

```python
import h5

for it in range(5):
    # DMFT loop
    with h5.HDFArchive("/tmp/test.h5", "a") as A:
        iteration = "it-{:03d}".format(it)
        A.create_group(iteration)
        A[iteration]["test"] = it
        A.create_softlink(iteration, "it-last")
```

```
$ h5ls /tmp/test.h5 
it-000                   Group
it-001                   Group
it-002                   Group
it-003                   Group
it-004                   Group
it-last                  Soft Link {it-004}
$ h5ls -d /tmp/test.h5/it-last/test
test                     Dataset {SCALAR}
    Data:
        (0) 4
```