### PR TITLE
Remove default copy constructor in group

### DIFF
--- a/c++/h5/group.hpp
+++ b/c++/h5/group.hpp
@@ -36,9 +36,6 @@ namespace h5 {
     /// Takes the "/" group at the top of the file
     group(file f);
 
-    ///
-    group(group const &) = default;
-
     private:
     // construct from the bare object and the parent
     // internal use only for open/create subgroup


### PR DESCRIPTION
The compiler issued a warning (when compiling TRIQS) that the generation of the implicitly-defined copy assignment operator is deprecated if T has a user-declared destructor or user-declared copy constructor (see https://en.cppreference.com/w/cpp/language/copy_assignment under "Implicitly-defined copy assignment operator").