### PR TITLE
Fix complex scalar attribute read and add std::variant attribute support

### DIFF
--- a/c++/h5/array_interface.cpp
+++ b/c++/h5/array_interface.cpp
@@ -262,10 +262,13 @@ namespace h5::array_interface {
     attribute attr = H5Aopen(obj, name.c_str(), H5P_DEFAULT);
     if (!attr.is_valid()) throw std::runtime_error("Error in h5::array_interface::read_attribute: Opening the attribute " + name + " failed");
 
-    // get dataspace information
+    // check that the attribute's rank matches the view's rank (write_attribute writes v.rank(), which is 1
+    // for complex scalars due to the trailing-2 FLOAT convention)
     dataspace space = H5Aget_space(attr);
     int rank        = H5Sget_simple_extent_ndims(space);
-    if (rank != 0) throw std::runtime_error("Error in h5::array_interface::read_attribute: Attribute " + name + " has a rank != 0");
+    if (rank != v.rank())
+      throw std::runtime_error("Error in h5::array_interface::read_attribute: Attribute " + name + " has rank " + std::to_string(rank)
+                               + " but the view has rank " + std::to_string(v.rank()));
 
     // get datatype information
     auto eq = H5Tequal(H5Aget_type(attr), v.ty);

--- a/c++/h5/object.cpp
+++ b/c++/h5/object.cpp
@@ -24,6 +24,7 @@
 #include "./object.hpp"
 #include "./utils.hpp"
 
+#include <H5Apublic.h>
 #include <H5Ipublic.h>
 #include <H5Fpublic.h>
 #include <H5Gpublic.h>
@@ -194,6 +195,11 @@ namespace h5 {
   }
 
   datatype get_hdf5_type(dataset ds) { return H5Dget_type(ds); }
+
+  datatype get_hdf5_attribute_type(object obj, std::string const &name) {
+    attribute attr = H5Aopen(obj, name.c_str(), H5P_DEFAULT);
+    return H5Aget_type(attr);
+  }
 
   bool hdf5_type_equal(datatype dt1, datatype dt2) {
     // for strings check only if they are both of the class H5T_STRING

--- a/c++/h5/object.hpp
+++ b/c++/h5/object.hpp
@@ -176,6 +176,15 @@ namespace h5 {
   [[nodiscard]] datatype get_hdf5_type(dataset ds);
 
   /**
+   * @brief Get the HDF5 type of a named attribute attached to a given h5::object.
+   *
+   * @param obj h5::object to which the attribute is attached.
+   * @param name Name of the attribute.
+   * @return h5::datatype of the given attribute.
+   */
+  [[nodiscard]] datatype get_hdf5_attribute_type(object obj, std::string const &name);
+
+  /**
    * @brief Check if two HDF5 datatypes are equal.
    *
    * @details For string types, this function only checks if they are both of the class `H5T_STRING`.

--- a/c++/h5/object.hpp
+++ b/c++/h5/object.hpp
@@ -168,6 +168,17 @@ namespace h5 {
   [[nodiscard]] std::string get_name_of_h5_type(datatype dt);
 
   /**
+   * @brief Get the name of the HDF5 datatype corresponding to a C++ type.
+   *
+   * @tparam T C++ type with a registered HDF5 datatype.
+   * @return String representation of the datatype.
+   */
+  template <typename T>
+  [[nodiscard]] std::string get_name_of_h5_type() {
+    return get_name_of_h5_type(hdf5_type<T>());
+  }
+
+  /**
    * @brief Get the HDF5 type stored in a given h5::dataset.
    *
    * @param ds h5::dataset.

--- a/c++/h5/stl/variant.hpp
+++ b/c++/h5/stl/variant.hpp
@@ -66,24 +66,23 @@ namespace h5 {
    * @warning This function only works, if name points to a dataset and not a group. Depending on the HDF5 datatype of
    * the dataset, it calls the specialized `h5_read`.
    *
-   * @tparam Ts Variant types.
+   * @tparam T,Ts Variant alternative types.
    * @param g h5::group containing the dataset.
    * @param name Name of the dataset from which the `std::variant` is read.
    * @param v `std::variant` to read into.
    */
-  template <typename... Ts>
-  void h5_read(group g, std::string const &name, std::variant<Ts...> &v) {
-    // name is a group --> triqs object
-    // assume for the moment, name is a dataset.
+  template <typename T, typename... Ts>
+  void h5_read(group g, std::string const &name, std::variant<T, Ts...> &v) {
     dataset ds    = g.open_dataset(name);
     datatype dt   = get_hdf5_type(ds);
-    auto try_read = [&]<typename T>(std::type_identity<T>) {
-      if (!hdf5_type_equal(hdf5_type<T>(), dt)) return false;
-      v = h5_read<T>(g, name);
+    auto try_read = [&]<typename U>(std::type_identity<U>) {
+      if (!hdf5_type_equal(hdf5_type<U>(), dt)) return false;
+      v = h5_read<U>(g, name);
       return true;
     };
-    if ((try_read(std::type_identity<Ts>{}) || ...)) return;
-    throw std::runtime_error("Error in h5_read for std::variant: stored HDF5 datatype matches no variant alternative");
+    if ((try_read(std::type_identity<T>{}) || ... || try_read(std::type_identity<Ts>{}))) return;
+    throw std::runtime_error("Error in h5_read for std::variant: stored HDF5 datatype matches no variant alternative (allowed: "
+                             + (get_name_of_h5_type<T>() + ... + (", " + get_name_of_h5_type<Ts>())) + ")");
   }
 
   /**
@@ -106,21 +105,22 @@ namespace h5 {
    *
    * @details Depending on the HDF5 datatype of the attribute, it calls the specialized `h5_read_attribute`.
    *
-   * @tparam Ts Variant types.
+   * @tparam T,Ts Variant alternative types.
    * @param obj h5::object to which the attribute is attached.
    * @param name Name of the attribute.
    * @param v `std::variant` to read into.
    */
-  template <typename... Ts>
-  void h5_read_attribute(object obj, std::string const &name, std::variant<Ts...> &v) {
+  template <typename T, typename... Ts>
+  void h5_read_attribute(object obj, std::string const &name, std::variant<T, Ts...> &v) {
     datatype dt   = get_hdf5_attribute_type(obj, name);
     auto try_read = [&]<typename U>(std::type_identity<U>) {
       if (!hdf5_type_equal(hdf5_type<U>(), dt)) return false;
       v = h5_read_attribute<U>(obj, name);
       return true;
     };
-    if ((try_read(std::type_identity<Ts>{}) || ...)) return;
-    throw std::runtime_error("Error in h5_read_attribute for std::variant: stored HDF5 datatype matches no variant alternative");
+    if ((try_read(std::type_identity<T>{}) || ... || try_read(std::type_identity<Ts>{}))) return;
+    throw std::runtime_error("Error in h5_read_attribute for std::variant: stored HDF5 datatype matches no variant alternative (allowed: "
+                             + (get_name_of_h5_type<T>() + ... + (", " + get_name_of_h5_type<Ts>())) + ")");
   }
 
   /** @} */

--- a/c++/h5/stl/variant.hpp
+++ b/c++/h5/stl/variant.hpp
@@ -29,6 +29,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <variant>
 
 namespace h5 {
@@ -95,6 +96,43 @@ namespace h5 {
     dataset ds  = g.open_dataset(name);
     datatype dt = get_hdf5_type(ds);
     detail::h5_read_variant_helper<std::variant<Ts...>, Ts...>(v, dt, g, name);
+  }
+
+  /**
+   * @brief Write a `std::variant` to an HDF5 attribute.
+   *
+   * @details Calls the specialized `h5_write_attribute` for the type currently stored in the `std::variant`.
+   *
+   * @tparam Ts Variant types.
+   * @param obj h5::object to which the attribute is attached.
+   * @param name Name of the attribute.
+   * @param v `std::variant` to be written.
+   */
+  template <typename... Ts>
+  void h5_write_attribute(object obj, std::string const &name, std::variant<Ts...> const &v) {
+    std::visit([&](auto const &x) { h5_write_attribute(obj, name, x); }, v);
+  }
+
+  /**
+   * @brief Read a `std::variant` from an HDF5 attribute.
+   *
+   * @details Depending on the HDF5 datatype of the attribute, it calls the specialized `h5_read_attribute`.
+   *
+   * @tparam Ts Variant types.
+   * @param obj h5::object to which the attribute is attached.
+   * @param name Name of the attribute.
+   * @param v `std::variant` to read into.
+   */
+  template <typename... Ts>
+  void h5_read_attribute(object obj, std::string const &name, std::variant<Ts...> &v) {
+    datatype dt   = get_hdf5_attribute_type(obj, name);
+    auto try_read = [&]<typename U>(std::type_identity<U>) {
+      if (!hdf5_type_equal(hdf5_type<U>(), dt)) return false;
+      v = std::variant<Ts...>{h5_read_attribute<U>(obj, name)};
+      return true;
+    };
+    if ((try_read(std::type_identity<Ts>{}) || ...)) return;
+    throw std::runtime_error("Error in h5_read_attribute for std::variant: stored HDF5 datatype matches no variant alternative");
   }
 
   /** @} */

--- a/c++/h5/stl/variant.hpp
+++ b/c++/h5/stl/variant.hpp
@@ -60,28 +60,10 @@ namespace h5 {
     std::visit([&](auto const &x) { h5_write(g, name, x); }, v);
   }
 
-  namespace detail {
-
-    // Helper function to read a `std::variant` from HDF5.
-    template <typename VT, typename U, typename... Ts>
-    void h5_read_variant_helper(VT &v, datatype dt, group g, std::string const &name) {
-      // finds the correct h5_read recursively
-      if (hdf5_type_equal(hdf5_type<U>(), dt)) {
-        v = VT{h5_read<U>(g, name)};
-        return;
-      }
-      if constexpr (sizeof...(Ts) > 0)
-        h5_read_variant_helper<VT, Ts...>(v, dt, g, name);
-      else
-        throw std::runtime_error("Error in h5_read_variant_helper: Type stored in the variant has no corresponding HDF5 datatype");
-    }
-
-  } // namespace detail
-
   /**
    * @brief Read a `std::variant` from an HDF5 dataset.
    *
-   * @warning This function only works, if name points to a dataset and not a group. Depending on the HDF5 datatype of 
+   * @warning This function only works, if name points to a dataset and not a group. Depending on the HDF5 datatype of
    * the dataset, it calls the specialized `h5_read`.
    *
    * @tparam Ts Variant types.
@@ -93,9 +75,15 @@ namespace h5 {
   void h5_read(group g, std::string const &name, std::variant<Ts...> &v) {
     // name is a group --> triqs object
     // assume for the moment, name is a dataset.
-    dataset ds  = g.open_dataset(name);
-    datatype dt = get_hdf5_type(ds);
-    detail::h5_read_variant_helper<std::variant<Ts...>, Ts...>(v, dt, g, name);
+    dataset ds    = g.open_dataset(name);
+    datatype dt   = get_hdf5_type(ds);
+    auto try_read = [&]<typename T>(std::type_identity<T>) {
+      if (!hdf5_type_equal(hdf5_type<T>(), dt)) return false;
+      v = h5_read<T>(g, name);
+      return true;
+    };
+    if ((try_read(std::type_identity<Ts>{}) || ...)) return;
+    throw std::runtime_error("Error in h5_read for std::variant: stored HDF5 datatype matches no variant alternative");
   }
 
   /**
@@ -128,7 +116,7 @@ namespace h5 {
     datatype dt   = get_hdf5_attribute_type(obj, name);
     auto try_read = [&]<typename U>(std::type_identity<U>) {
       if (!hdf5_type_equal(hdf5_type<U>(), dt)) return false;
-      v = std::variant<Ts...>{h5_read_attribute<U>(obj, name)};
+      v = h5_read_attribute<U>(obj, name);
       return true;
     };
     if ((try_read(std::type_identity<Ts>{}) || ...)) return;

--- a/test/c++/h5_complex.cpp
+++ b/test/c++/h5_complex.cpp
@@ -44,6 +44,23 @@ TEST(H5, ComplexBackwardCompatibility) {
   }
 };
 
+TEST(H5, ComplexAttribute) {
+  // write and read a std::complex<double> scalar as an HDF5 attribute
+  std::complex<double> z{1.0, 2.0};
+
+  {
+    h5::file file("complex_attr.h5", 'w');
+    h5::write_attribute(file, "z", z);
+  }
+
+  {
+    h5::file file("complex_attr.h5", 'r');
+    std::complex<double> z_in;
+    h5::read_attribute(file, "z", z_in);
+    EXPECT_EQ(z, z_in);
+  }
+};
+
 TEST(H5, ComplexCompoundType) {
   // write an array of h5::dxplx_t and read it into an array of std::complex<double>
   std::array<h5::dcplx_t, 4> arr = {h5::dcplx_t{0.0, 0.0}, h5::dcplx_t{0.0, 1.0}, h5::dcplx_t{1.0, 0.0}, h5::dcplx_t{1.0, 1.0}};

--- a/test/c++/h5_variant.cpp
+++ b/test/c++/h5_variant.cpp
@@ -73,3 +73,57 @@ TEST(H5, VariantIntString) {
     EXPECT_EQ(std::get<std::string>(v2), s);
   }
 }
+
+TEST(H5, VariantAttributeIntComplex) {
+  // write/read a variant of int and complex as an HDF5 attribute
+  using v_t = std::variant<int, std::complex<double>>;
+  std::complex<double> z{1, 2};
+  int i{6};
+
+  {
+    h5::file file("test_variantIC_attr.h5", 'w');
+
+    auto v1 = v_t{i};
+    auto v2 = v_t{z};
+    h5::write_attribute(file, "v1", v1);
+    h5::write_attribute(file, "v2", v2);
+  }
+
+  {
+    h5::file file("test_variantIC_attr.h5", 'r');
+
+    v_t v1, v2;
+    h5::read_attribute(file, "v1", v1);
+    h5::read_attribute(file, "v2", v2);
+
+    EXPECT_EQ(std::get<int>(v1), i);
+    EXPECT_EQ(std::get<std::complex<double>>(v2), z);
+  }
+}
+
+TEST(H5, VariantAttributeIntString) {
+  // write/read a variant of int and string as an HDF5 attribute
+  using v_t = std::variant<int, std::string>;
+  std::string s{"Hello"};
+  int i{6};
+
+  {
+    h5::file file("test_variantIS_attr.h5", 'w');
+
+    auto v1 = v_t{i};
+    auto v2 = v_t{s};
+    h5::write_attribute(file, "v1", v1);
+    h5::write_attribute(file, "v2", v2);
+  }
+
+  {
+    h5::file file("test_variantIS_attr.h5", 'r');
+
+    v_t v1, v2;
+    h5::read_attribute(file, "v1", v1);
+    h5::read_attribute(file, "v2", v2);
+
+    EXPECT_EQ(std::get<int>(v1), i);
+    EXPECT_EQ(std::get<std::string>(v2), s);
+  }
+}


### PR DESCRIPTION
## Summary

Three small attribute-side improvements to the HDF5 wrappers:

- **Fix `std::complex` scalar attribute read.** `array_interface::write_attribute` writes complex scalars with rank 1 (trailing-2 FLOAT convention), but `read_attribute` hard-coded `rank == 0` and threw on read. The rank check now matches the view's rank, making the round-trip symmetric.
- **Add `std::variant` attribute support.** New `h5_write_attribute` / `h5_read_attribute` overloads mirror the existing dataset-side dispatch: write visits the active alternative; read recovers it by matching the attribute's HDF5 datatype against each variant member via `hdf5_type_equal`. A small `get_hdf5_type_attribute` helper is added to `object.{hpp,cpp}` so `stl/variant.hpp` stays free of HDF5 headers.
- **Inline `h5_read_variant_helper`.** Replace the recursive `detail::h5_read_variant_helper` in the dataset-side `h5_read` with an inline short-circuit fold over the variant alternatives, matching the form already used by `h5_read_attribute`. No behavior change.

Tests in `test/c++/h5_complex.cpp` and `test/c++/h5_variant.cpp` were extended accordingly.