### PR TITLE
[fix] sort archive group keys for deterministic iteration order

### DIFF
--- a/python/h5/archive_basic_layer.py
+++ b/python/h5/archive_basic_layer.py
@@ -24,8 +24,13 @@ class HDFArchiveGroupBasicLayer:
         """  """
         self.options = parent.options
         self._group = parent._group.open_group(subpath) if subpath else parent._group
-        self.ignored_keys = [] 
-        self.cached_keys = list(self._group.keys())
+        self.ignored_keys = []
+        # Sort the keys so that group iteration order is deterministic and
+        # independent of the HDF5 native link iteration order, which is not
+        # stable across HDF5/Python versions. This guarantees, e.g., that block
+        # Green's functions reconstructed from an archive have a reproducible
+        # (alphabetical) block order.
+        self.cached_keys = sorted(self._group.keys())
 
     def _init_root(self, descriptor, open_flag) :
         if descriptor is None:


### PR DESCRIPTION
Reading an HDF5 group returns its keys in HDF5 *native* iteration order (`HDFArchiveGroupBasicLayer.cached_keys = list(self._group.keys())`), which is not stable across HDF5/Python versions. As a result, a Python `dict` reconstructed from a group comes back with an arbitrary key order.

### Where it occured
Under **Python 3.14**, `triqs_dft_tools.BlockStructure.gf_struct_solver` (a dict stored in the archive) read back with its blocks reordered (e.g. `up_0,up_1,up_2,down_0,down_2,down_1` instead of insertion order). Block Green's functions rebuilt from that dict then had an unpredictable block order, so `assert_block_gfs_are_close` failed with `block name up_0 does not match down_0` even though the data was identical (~1e-13). It surfaced as a failing `restart_svo_hubbardI_basic` test in solid_dmft. Two dicts with identical Python key order could even serialize to *different* orders in the same file.

### Fix
Sort `cached_keys` on read so group iteration is deterministic (alphabetical) and independent of the native HDF5 link order. `List`/`Tuple` reconstruction re-sorts by integer key internally, so they are unaffected. The other possible fix for the test is to make it agnostic to the order, but that could still bite users in production.

Note: this is the Python-layer fix. The C++ `group::get_all_subgroup_names()` / `get_all_dataset_names()` still use `H5_ITER_NATIVE`; typed readers (`block_gf`, `gf_struct`, arrays) store their own ordering metadata and are unaffected.