### PR TITLE
wip: Expose HDF5 type conversion handling

### DIFF
--- a/c++/h5/array_interface.cpp
+++ b/c++/h5/array_interface.cpp
@@ -23,12 +23,12 @@
 #include "./complex.hpp"
 #include "./macros.hpp"
 #include "./stl/string.hpp"
+#include "./transfer.hpp"
 
 #include <hdf5.h>
 #include <hdf5_hl.h>
 
 #include <algorithm>
-#include <iostream>
 #include <numeric>
 #include <stdexcept>
 #include <utility>
@@ -152,7 +152,7 @@ namespace h5::array_interface {
 
     // write to the file dataset
     if (H5Sget_simple_extent_npoints(mem_dspace) > 0) { // avoid writing empty arrays
-      herr_t err = H5Dwrite(ds, v.ty, mem_dspace, H5S_ALL, H5P_DEFAULT, v.start);
+      herr_t err = H5Dwrite(ds, v.ty, mem_dspace, H5S_ALL, default_transfer_plist(), v.start);
       if (err < 0)
         throw std::runtime_error("Error in h5::array_interface::write: Writing to the dataset " + name + " in the group" + g.name() + " failed");
     }
@@ -169,9 +169,7 @@ namespace h5::array_interface {
     if (v.slab.size() != sl.size()) throw std::runtime_error("Error in h5::array_interface::write_slice: Incompatible sizes");
 
     auto ds_info = get_dataset_info(g, name);
-    if (not hdf5_type_equal(v.ty, ds_info.ty))
-      throw std::runtime_error("Error in h5::array_interface::write_slice: Incompatible HDF5 types: " + get_name_of_h5_type(v.ty)
-                               + " != " + get_name_of_h5_type(ds_info.ty));
+    if (not hdf5_type_equal(v.ty, ds_info.ty)) { detail::handle_type_conversion_callback(v.ty, ds_info.ty, "Error in h5::array_interface::write_slice"); }
 
     // open existing dataset, get dataspace and select hyperslab
     dataset ds            = g.open_dataset(name);
@@ -185,9 +183,10 @@ namespace h5::array_interface {
 
     // write to the selected hyperslab of the file dataset
     if (H5Sget_simple_extent_npoints(file_dspace) > 0) {
-      err = H5Dwrite(ds, v.ty, mem_dspace, file_dspace, H5P_DEFAULT, v.start);
+      err = H5Dwrite(ds, v.ty, mem_dspace, file_dspace, default_transfer_plist(), v.start);
       if (err < 0)
-        throw std::runtime_error("Error in h5::array_interface::write_slice: Writing the dataset " + name + " in the group " + g.name() + " failed");
+        throw std::runtime_error("Error in h5::array_interface::write_slice: Writing the dataset " + name + " in the group " + g.name()
+                                 + " failed (converting " + get_name_of_h5_type(v.ty) + " -> " + get_name_of_h5_type(ds_info.ty) + ")");
     }
   }
 
@@ -203,7 +202,8 @@ namespace h5::array_interface {
     attribute attr = H5Acreate2(obj, name.c_str(), v.ty, mem_dspace, H5P_DEFAULT, H5P_DEFAULT);
     if (!attr.is_valid()) throw std::runtime_error("Error in h5::array_interface::write_attribute: Creating the attribute " + name + " failed");
 
-    // write to the attribute
+    // write to the attribute (H5Awrite takes no transfer property list, so attribute conversions cannot be
+    // routed through the global dataset transfer property list / conversion callback)
     herr_t err = H5Awrite(attr, v.ty, v.start);
     if (err < 0) throw std::runtime_error("Error in h5::array_interface::write_attribute: Writing to the attribute " + name + " failed");
   }
@@ -220,7 +220,6 @@ namespace h5::array_interface {
       if (err < 0) throw std::runtime_error("Error in h5::array_interface::read: selecting the hyperslab failed");
     }
 
-    // check consistency of input
     auto ds_info = get_dataset_info(g, name);
 
     // file dataset uses the {r:double, i:double} compound type (Julia HDF5.jl, h5py): retype the view to dcplx_t and drop the trailing-2 dim
@@ -234,13 +233,7 @@ namespace h5::array_interface {
       v.slab.block.pop_back();
     }
 
-    if (H5Tget_class(v.ty) != H5Tget_class(ds_info.ty))
-      throw std::runtime_error("Error in h5::array_interface::read: Incompatible HDF5 types: " + get_name_of_h5_type(v.ty)
-                               + " != " + get_name_of_h5_type(ds_info.ty));
-
-    if (not hdf5_type_equal(v.ty, ds_info.ty))
-      std::cerr << "WARNING: HDF5 type mismatch while reading into an array_view: " + get_name_of_h5_type(v.ty)
-            + " != " + get_name_of_h5_type(ds_info.ty) + "\n";
+    if (not hdf5_type_equal(v.ty, ds_info.ty)) { detail::handle_type_conversion_callback(ds_info.ty, v.ty, "Error in h5::array_interface::read"); }
 
     auto sl_size = sl.size();
     if (sl.empty()) { sl_size = std::accumulate(ds_info.lengths.begin(), ds_info.lengths.end(), (hsize_t)1, std::multiplies<>()); }
@@ -251,9 +244,10 @@ namespace h5::array_interface {
 
     // read the selected hyperslab from the file dataset
     if (H5Sget_simple_extent_npoints(file_dspace) > 0) {
-      herr_t err = H5Dread(ds, v.ty, mem_dspace, file_dspace, H5P_DEFAULT, v.start);
+      herr_t err = H5Dread(ds, v.ty, mem_dspace, file_dspace, default_transfer_plist(), v.start);
       if (err < 0)
-        throw std::runtime_error("Error in h5::array_interface::read: Reading the dataset " + name + " in the group " + g.name() + " failed");
+        throw std::runtime_error("Error in h5::array_interface::read: Reading the dataset " + name + " in the group " + g.name()
+                                 + " failed (converting " + get_name_of_h5_type(ds_info.ty) + " -> " + get_name_of_h5_type(v.ty) + ")");
     }
   }
 

--- a/c++/h5/h5.hpp
+++ b/c++/h5/h5.hpp
@@ -32,6 +32,7 @@
 #include "./scalar.hpp"
 #include "./serialization.hpp"
 #include "./storable.hpp"
+#include "./transfer.hpp"
 #include "./utils.hpp"
 #include "./stl/string.hpp"
 #include "./stl/array.hpp"

--- a/c++/h5/stl/array.hpp
+++ b/c++/h5/stl/array.hpp
@@ -25,10 +25,10 @@
 #include "../array_interface.hpp"
 #include "../complex.hpp"
 #include "../macros.hpp"
+#include "../transfer.hpp"
 
 #include <algorithm>
 #include <array>
-#include <iostream>
 #include <string>
 #include <type_traits>
 
@@ -104,8 +104,7 @@ namespace h5 {
 
         // read non-complex data into std::array<std::complex>
         if (!ds_info.has_complex_attribute) {
-          std::cerr << "WARNING: HDF5 type mismatch while reading into a std::array: std::complex<" + get_name_of_h5_type(hdf5_type<T>())
-                + "> != " + get_name_of_h5_type(ds_info.ty) + "\n";
+          detail::handle_type_conversion_callback(ds_info.ty, hdf5_type<T>(), "Error in h5_read into std::array");
           std::array<double, N> tmp{};
           h5_read(g, name, tmp);
           std::copy(begin(tmp), end(tmp), begin(a));

--- a/c++/h5/stl/string.cpp
+++ b/c++/h5/stl/string.cpp
@@ -21,6 +21,7 @@
 
 #include "./string.hpp"
 #include "../macros.hpp"
+#include "../transfer.hpp"
 #include "../utils.hpp"
 
 #include <hdf5.h>
@@ -60,7 +61,7 @@ namespace h5 {
 
     // write the string to dataset
     auto *s_ptr = s.c_str();
-    auto err    = H5Dwrite(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, (void const *)&s_ptr);
+    auto err    = H5Dwrite(ds, dt, H5S_ALL, H5S_ALL, default_transfer_plist(), (void const *)&s_ptr);
     if (err < 0) throw std::runtime_error("Error in h5_write: Writing a string to the dataset " + name + " in the group " + g.name() + " failed");
   }
 
@@ -81,16 +82,16 @@ namespace h5 {
     if (H5Tis_variable_str(dt)) {
       // first read into a char* pointer, then copy into the string
       std::array<char *, 1> rd_ptr{nullptr};
-      auto err = H5Dread(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, (void *)rd_ptr.data());
+      auto err = H5Dread(ds, dt, H5S_ALL, H5S_ALL, default_transfer_plist(), (void *)rd_ptr.data());
       if (err < 0) throw std::runtime_error("Error in h5_read: Reading a string from the dataset " + name + " in the group " + g.name() + " failed");
       s.append(rd_ptr[0]);
 
       // free the resources allocated in the variable-length read
-      err = H5Dvlen_reclaim(dt, dspace, H5P_DEFAULT, (void *)rd_ptr.data());
+      err = H5Dvlen_reclaim(dt, dspace, default_transfer_plist(), (void *)rd_ptr.data());
       if (err < 0) throw std::runtime_error("Error in h5_read: Freeing resources after reading a variable-length string failed");
     } else { // fixed-sized string
       std::vector<char> buf(H5Tget_size(dt) + 1, 0x00);
-      auto err = H5Dread(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, &buf[0]);
+      auto err = H5Dread(ds, dt, H5S_ALL, H5S_ALL, default_transfer_plist(), &buf[0]);
       if (err < 0) throw std::runtime_error("Error in h5_read: Reading a string from the dataset " + name + " in the group " + g.name() + " failed");
       s.append(&buf.front());
     }
@@ -134,7 +135,7 @@ namespace h5 {
       s.append(rd_ptr[0]);
 
       // free the resources allocated in the variable-length read
-      err = H5Dvlen_reclaim(dt, dspace, H5P_DEFAULT, (void *)rd_ptr.data());
+      err = H5Dvlen_reclaim(dt, dspace, default_transfer_plist(), (void *)rd_ptr.data());
       if (err < 0) throw std::runtime_error("Error in h5_read_attribute: Freeing resources after reading a variable-length string failed");
     } else { // fixed-sized string
       std::vector<char> buf(H5Tget_size(dt) + 1, 0x00);
@@ -181,7 +182,7 @@ namespace h5 {
       s.append(rd_ptr[0]);
 
       // free the resources allocated in the variable-length read
-      err = H5Dvlen_reclaim(dt, dspace, H5P_DEFAULT, (void *)rd_ptr.data());
+      err = H5Dvlen_reclaim(dt, dspace, default_transfer_plist(), (void *)rd_ptr.data());
       if (err < 0) throw std::runtime_error("Error in h5_read_attribute_to_key: Rreeing resources after reading a variable-length string failed");
     } else { // fixed-sized string
       std::vector<char> buf(H5Tget_size(dt) + 1, 0x00);
@@ -208,7 +209,7 @@ namespace h5 {
     dataset ds  = g.create_dataset(name, dt, dspace);
 
     // write to the dataset
-    auto err = H5Dwrite(ds, dt, dspace, H5S_ALL, H5P_DEFAULT, (void *)cb.buffer.data());
+    auto err = H5Dwrite(ds, dt, dspace, H5S_ALL, default_transfer_plist(), (void *)cb.buffer.data());
     if (err < 0) throw make_runtime_error("Error in h5_write: Writing a char_buf to the dataset ", name, " in the group ", g.name(), " failed");
   }
 
@@ -233,7 +234,7 @@ namespace h5 {
 
     // read into the buffer
     H5_ASSERT(hdf5_type_equal(ty, cb_out.dtype()));
-    auto err = H5Dread(ds, ty, cb_out.dspace(), H5S_ALL, H5P_DEFAULT, (void *)cb_out.buffer.data());
+    auto err = H5Dread(ds, ty, cb_out.dspace(), H5S_ALL, default_transfer_plist(), (void *)cb_out.buffer.data());
     if (err < 0) throw make_runtime_error("Error in h5_read: Reading a char_buf from the dataset ", name, " in the group ", g.name(), " failed");
 
     // move to output char_buf

--- a/c++/h5/transfer.cpp
+++ b/c++/h5/transfer.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2019-2024 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Lukas Weber
+
+/**
+ * @file
+ * @brief Implementation details for transfer.hpp.
+ */
+
+#include "./transfer.hpp"
+#include "./object.hpp"
+
+#include <hdf5.h>
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace h5 {
+
+  // anonymous namespace for internal functions
+  namespace {
+
+    // The built-in default conversion callback: warn for the h5-specific mismatch situations and stay silent
+    // (unhandled) for HDF5's native per-element exceptions, preserving the historical behavior.
+    conv_ret default_type_conv_cb(conv_except except, datatype src, datatype dst, void * /*src_buf*/, void * /*dst_buf*/) {
+      if (except == conv_except::not_equal or except == conv_except::narrower) {
+        std::cerr << "WARNING: HDF5 type mismatch, converting " + get_name_of_h5_type(src) + " -> " + get_name_of_h5_type(dst)
+              + (except == conv_except::narrower ? " (narrowing)" : "") + "\n";
+      }
+      return conv_ret::unhandled;
+    }
+
+    // Storage for the library-global conversion callback (lazily initialized to the default).
+    type_conv_cb_t &cb_ref() {
+      static type_conv_cb_t cb = default_type_conv_cb;
+      return cb;
+    }
+
+    // Map an HDF5 native exception type to the h5 enum.
+    conv_except conv_except_of(H5T_conv_except_t except_type) {
+      switch (except_type) {
+        case H5T_CONV_EXCEPT_RANGE_HI: return conv_except::range_hi;
+        case H5T_CONV_EXCEPT_RANGE_LOW: return conv_except::range_low;
+        case H5T_CONV_EXCEPT_PRECISION: return conv_except::precision;
+        case H5T_CONV_EXCEPT_TRUNCATE: return conv_except::truncate;
+        case H5T_CONV_EXCEPT_PINF: return conv_except::pinf;
+        case H5T_CONV_EXCEPT_NINF: return conv_except::ninf;
+        case H5T_CONV_EXCEPT_NAN: return conv_except::nan;
+        default: return conv_except::not_equal; // should not happen, mapped defensively
+      }
+    }
+
+    // Trampoline handed to HDF5 via H5Pset_type_conv_cb. Its signature must match H5T_conv_except_func_t
+    // (stable since HDF5 1.8): the src/dst data buffers are passed on to the callback, only user_data is unused.
+    // It must not let C++ exceptions escape into the HDF5 C call stack, so a throwing callback is turned into
+    // an abort of the conversion (which HDF5 surfaces as a failed H5Dread/H5Dwrite).
+    H5T_conv_ret_t type_conv_trampoline(H5T_conv_except_t except_type, ::hid_t src_id, ::hid_t dst_id, void *src_buf,
+                                        void *dst_buf, void * /*user_data*/) {
+      auto const &cb = cb_ref();
+      if (not cb) return H5T_CONV_UNHANDLED;
+      try {
+        conv_ret const r = cb(conv_except_of(except_type), object::from_borrowed(src_id), object::from_borrowed(dst_id), src_buf, dst_buf);
+        return static_cast<H5T_conv_ret_t>(static_cast<int>(r));
+      } catch (std::exception const &e) {
+        std::cerr << "WARNING: exception thrown from the HDF5 type conversion callback was swallowed: " << e.what() << "\n";
+        return H5T_CONV_ABORT;
+      }
+    }
+
+    // Create the global dataset transfer property list and install the conversion callback trampoline.
+    proplist make_default_transfer_plist() {
+      proplist p = H5Pcreate(H5P_DATASET_XFER);
+      if (not p.is_valid()) throw std::runtime_error("Error in h5: creating the global dataset transfer property list failed");
+      if (H5Pset_type_conv_cb(p, &type_conv_trampoline, nullptr) < 0)
+        throw std::runtime_error("Error in h5: H5Pset_type_conv_cb on the global dataset transfer property list failed");
+      return p;
+    }
+
+    // Check whether converting from src to dst is a narrowing conversion.
+    bool is_narrowing(datatype src, datatype dst) {
+      // different classes are not comparable here (and H5Tget_precision is meaningless e.g. for compounds)
+      if (H5Tget_class(src) != H5Tget_class(dst)) return false;
+      // fewer bits of precision in the destination loses information
+      if (H5Tget_precision(dst) < H5Tget_precision(src)) return true;
+      // a change of signedness between integers can lose values even at equal precision
+      if (H5Tget_class(src) == H5T_INTEGER and H5Tget_sign(src) != H5Tget_sign(dst)) return true;
+      return false;
+    }
+
+  } // namespace
+
+  void set_type_conv_cb(type_conv_cb_t cb) { cb_ref() = (cb ? std::move(cb) : type_conv_cb_t{default_type_conv_cb}); }
+
+  type_conv_cb_t const &get_type_conv_cb() { return cb_ref(); }
+
+  proplist &default_transfer_plist() {
+    static proplist p = make_default_transfer_plist();
+    return p;
+  }
+
+  namespace detail {
+
+    void handle_type_conversion_callback(datatype src, datatype dst, std::string const &context) {
+      conv_except const kind = is_narrowing(src, dst) ? conv_except::narrower : conv_except::not_equal;
+      // these h5-specific (custom) cases are whole-dataset type mismatches: there is no per-element buffer, so the
+      // src/dst data pointers handed to the callback are null
+      if (cb_ref()(kind, src, dst, nullptr, nullptr) == conv_ret::abort) {
+        throw std::runtime_error(context + ": datatype conversion aborted by callback: " + get_name_of_h5_type(src) + " -> "
+                                 + get_name_of_h5_type(dst));
+      }
+    }
+
+  } // namespace detail
+
+} // namespace h5

--- a/c++/h5/transfer.hpp
+++ b/c++/h5/transfer.hpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2019-2024 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Lukas Weber
+
+/**
+ * @file
+ * @brief Provides a library-global dataset transfer property list and a
+ * user-overridable datatype conversion callback.
+ */
+
+#ifndef LIBH5_TRANSFER_HPP
+#define LIBH5_TRANSFER_HPP
+
+#include "./object.hpp"
+
+#include <functional>
+
+namespace h5 {
+
+  /**
+   * @addtogroup data_model
+   * @{
+   */
+
+  /**
+   * @brief Possible return values of an h5::type_conv_cb_t.
+   *
+   * @details Mirrors HDF5's `H5T_conv_ret_t`. It tells HDF5 (and, for the h5-specific exceptions,
+   * the h5 library) how to proceed after the callback has run.
+   */
+  enum class conv_ret {
+    abort     = -1, ///< Abort the conversion (h5 turns this into a thrown exception).
+    unhandled = 0,  ///< The callback did not handle the exception; fall back to HDF5's default behavior.
+    handled   = 1   ///< The callback handled the exception.
+  };
+
+  /**
+   * @brief Datatype conversion situations that can trigger the conversion callback.
+   *
+   * @details The first block mirrors HDF5's `H5T_conv_except_t`. These are genuine per-element conversion
+   * exceptions raised by HDF5 during `H5Dread`/`H5Dwrite` and delivered through the callback installed on the
+   * global transfer property list via `H5Pset_type_conv_cb`.
+   *
+   * The last two values (#not_equal and #narrower) are h5 additions. HDF5 never raises them on its own (it only
+   * reports per-value exceptions, not the mere fact that two datatypes differ), so the h5 library detects these
+   * cases and invokes the callback manually at the read/write call sites.
+   */
+  enum class conv_except {
+    range_hi,  ///< Source value is above the range of the destination type.
+    range_low, ///< Source value is below the range of the destination type.
+    precision, ///< Precision was lost in the conversion.
+    truncate,  ///< A floating point value was truncated during the conversion.
+    pinf,      ///< Source value is positive infinity.
+    ninf,      ///< Source value is negative infinity.
+    nan,       ///< Source value is not a number.
+    not_equal, ///< (h5) The source and destination datatypes are not exactly equal.
+    narrower   ///< (h5) The destination datatype is narrower than the source datatype.
+  };
+
+  /**
+   * @brief Type of the user-overridable datatype conversion callback.
+   *
+   * @details `src` is the source datatype, `dst` the destination datatype: on read, the file type is the
+   * source and the in-memory type the destination; on write it is the other way around.
+   *
+   * `src_buf` and `dst_buf` are the void pointers to the source and destination data being converted (paired
+   * with `src`/`dst`). For HDF5's native per-element exceptions they point to the offending source element and
+   * its destination slot, so a callback may inspect or patch the value in place. For the h5-specific
+   * #conv_except::not_equal and #conv_except::narrower cases (raised manually by the h5 library at the
+   * read/write call sites, see detail::handle_type_conversion_callback) **both pointers are `nullptr`**: those
+   * are whole-dataset datatype mismatches with no single offending element to point at.
+   */
+  using type_conv_cb_t = std::function<conv_ret(conv_except except, datatype src, datatype dst, void *src_buf, void *dst_buf)>;
+
+  /**
+   * @brief Set the library-global datatype conversion callback.
+   *
+   * @details The callback is consulted for HDF5's native per-element conversion exceptions (via the global
+   * transfer property list, see h5::default_transfer_plist) as well as for the h5-specific #conv_except::not_equal
+   * and #conv_except::narrower situations detected during reading/writing.
+   *
+   * The callback is a single process-global: setting it replaces the previous one everywhere, there is no
+   * per-file or per-call scoping, and it is not synchronized against concurrent I/O. Note that HDF5 delivers its
+   * native exceptions once per offending element, so a callback that logs may be invoked many times for a single
+   * lossy read.
+   *
+   * Passing an empty std::function restores the built-in default, which prints a warning to `std::cerr` for the
+   * #conv_except::not_equal and #conv_except::narrower cases and stays silent (returns #conv_ret::unhandled) for
+   * HDF5's native exceptions.
+   *
+   * @param cb Callback to install, or `{}` to restore the default.
+   */
+  void set_type_conv_cb(type_conv_cb_t cb);
+
+  /**
+   * @brief Get the currently installed datatype conversion callback.
+   * @return The current h5::type_conv_cb_t.
+   */
+  [[nodiscard]] type_conv_cb_t const &get_type_conv_cb();
+
+  /**
+   * @brief Get the library-global dataset transfer property list.
+   *
+   * @details Used as the transfer property list argument in all `H5Dread`/`H5Dwrite` calls. It is created lazily
+   * (as an `H5P_DATASET_XFER` property list) on first use and has the conversion callback trampoline installed via
+   * `H5Pset_type_conv_cb`. Advanced users may set additional transfer properties on it.
+   *
+   * @return Reference to the global h5::proplist.
+   */
+  [[nodiscard]] proplist &default_transfer_plist();
+
+  namespace detail {
+
+    /**
+     * @brief Report a datatype mismatch through the conversion callback, throwing if the callback aborts.
+     *
+     * @details Classifies the mismatch as #conv_except::narrower (if the destination is narrower than the source)
+     * or #conv_except::not_equal otherwise, invokes the global callback, and throws a std::runtime_error if the
+     * callback returns #conv_ret::abort.
+     *
+     * @param src Source datatype.
+     * @param dst Destination datatype.
+     * @param context Prefix for the exception message (e.g. the calling function).
+     */
+    void handle_type_conversion_callback(datatype src, datatype dst, std::string const &context);
+
+  } // namespace detail
+
+  /** @} */
+
+} // namespace h5
+
+#endif // LIBH5_TRANSFER_HPP

--- a/test/c++/h5_type_conv.cpp
+++ b/test/c++/h5_type_conv.cpp
@@ -1,0 +1,224 @@
+// Copyright (c) 2024 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Lukas Weber
+
+#include <gtest/gtest.h>
+#include <h5/h5.hpp>
+
+#include <hdf5.h>
+
+#include <algorithm>
+#include <numeric>
+#include <string>
+#include <vector>
+
+// Restore the built-in default conversion callback when leaving a scope.
+struct cb_guard {
+  ~cb_guard() { h5::set_type_conv_cb({}); }
+};
+
+// Read into the destination type and return the list of conversion situations the callback observed.
+template <typename Dst>
+std::vector<h5::conv_except> read_collecting(h5::group g, std::string const &name, std::vector<Dst> &out) {
+  std::vector<h5::conv_except> calls;
+  h5::set_type_conv_cb([&calls](h5::conv_except e, h5::datatype, h5::datatype, void *, void *) {
+    calls.push_back(e);
+    return h5::conv_ret::unhandled;
+  });
+  h5::h5_read(g, name, out);
+  return calls;
+}
+
+TEST(H5TypeConv, WideningReportsNotEqual) {
+  cb_guard guard;
+  h5::file f("type_conv.h5", 'w');
+
+  std::vector<int> data(5);
+  std::iota(data.begin(), data.end(), 0);
+  h5::h5_write(f, "ints", data);
+
+  // int -> long is a lossless widening: reported as not_equal, never narrower
+  std::vector<long> out;
+  auto calls = read_collecting(f, "ints", out);
+
+  ASSERT_EQ(calls.size(), 1u);
+  EXPECT_EQ(calls[0], h5::conv_except::not_equal);
+  ASSERT_EQ(out.size(), data.size());
+  for (size_t i = 0; i < data.size(); ++i) { EXPECT_EQ(out[i], static_cast<long>(data[i])); }
+}
+
+TEST(H5TypeConv, NarrowingReportsNarrower) {
+  cb_guard guard;
+  h5::file f("type_conv.h5", 'w');
+
+  std::vector<int> data(5);
+  std::iota(data.begin(), data.end(), 0);
+  h5::h5_write(f, "ints", data);
+
+  // int -> short loses precision: reported as narrower (values still fit, so HDF5 itself raises no exception)
+  std::vector<short> out;
+  auto calls = read_collecting(f, "ints", out);
+
+  ASSERT_EQ(calls.size(), 1u);
+  EXPECT_EQ(calls[0], h5::conv_except::narrower);
+  ASSERT_EQ(out.size(), data.size());
+  for (size_t i = 0; i < data.size(); ++i) { EXPECT_EQ(out[i], static_cast<short>(data[i])); }
+}
+
+TEST(H5TypeConv, AbortThrows) {
+  cb_guard guard;
+  h5::file f("type_conv.h5", 'w');
+
+  std::vector<int> data{1, 2, 3};
+  h5::h5_write(f, "ints", data);
+
+  h5::set_type_conv_cb([](h5::conv_except, h5::datatype, h5::datatype, void *, void *) { return h5::conv_ret::abort; });
+
+  std::vector<long> out;
+  EXPECT_THROW(h5::h5_read(f, "ints", out), std::runtime_error);
+}
+
+TEST(H5TypeConv, DefaultCallbackRestoredAndSilentNativeRead) {
+  cb_guard guard;
+  h5::file f("type_conv.h5", 'w');
+
+  std::vector<int> data{1, 2, 3};
+  h5::h5_write(f, "ints", data);
+
+  // install then restore the default; an equal-type read must not invoke the callback nor throw
+  h5::set_type_conv_cb([](h5::conv_except, h5::datatype, h5::datatype, void *, void *) { return h5::conv_ret::abort; });
+  h5::set_type_conv_cb({});
+
+  std::vector<int> out;
+  EXPECT_NO_THROW(h5::h5_read(f, "ints", out));
+  ASSERT_EQ(out.size(), data.size());
+  for (size_t i = 0; i < data.size(); ++i) { EXPECT_EQ(out[i], data[i]); }
+}
+
+TEST(H5TypeConv, CrossClassConversionIsAllowed) {
+  cb_guard guard;
+  h5::file f("type_conv.h5", 'w');
+
+  // whole-valued doubles convert cleanly to int (HDF5 raises no per-element exception)
+  std::vector<double> data{0.0, 1.0, 2.0, 3.0};
+  h5::h5_write(f, "doubles", data);
+
+  std::vector<int> out;
+  auto calls = read_collecting(f, "doubles", out);
+
+  // previously this threw on the class-mismatch pre-check; now HDF5 performs the conversion
+  ASSERT_EQ(out.size(), data.size());
+  for (size_t i = 0; i < data.size(); ++i) { EXPECT_EQ(out[i], static_cast<int>(data[i])); }
+  // the (manual) mismatch situation is reported as not_equal (differing classes are not classified as narrower)
+  EXPECT_NE(std::find(calls.begin(), calls.end(), h5::conv_except::not_equal), calls.end());
+}
+
+TEST(H5TypeConv, NativeExceptionReachesCallback) {
+  cb_guard guard;
+  h5::file f("type_conv.h5", 'w');
+
+  // fractional doubles -> int truncate during conversion: HDF5 delivers a native per-element exception
+  // through the trampoline installed on the global transfer property list
+  std::vector<double> data{0.5, 1.5, 2.5};
+  h5::h5_write(f, "fracs", data);
+
+  std::vector<int> out;
+  auto calls = read_collecting(f, "fracs", out);
+
+  bool const saw_native = std::any_of(calls.begin(), calls.end(), [](h5::conv_except e) {
+    return e == h5::conv_except::truncate or e == h5::conv_except::precision;
+  });
+  EXPECT_TRUE(saw_native);
+  EXPECT_EQ(out.size(), data.size());
+}
+
+TEST(H5TypeConv, UnconvertiblePairThrowsWithTypeNames) {
+  cb_guard guard;
+  h5::file f("type_conv.h5", 'w');
+
+  // write a plain 1D int dataset via the array interface
+  std::vector<int> data{1, 2, 3};
+  h5::array_interface::array_view wv(h5::hdf5_type<int>(), (void *)data.data(), 1, false);
+  wv.slab.count[0]   = static_cast<h5::hsize_t>(data.size());
+  wv.parent_shape[0] = static_cast<h5::hsize_t>(data.size());
+  h5::array_interface::write(f, "ints", wv, false);
+
+  // there is no conversion path from integer to string, so H5Dread fails and we throw
+  h5::set_type_conv_cb([](h5::conv_except, h5::datatype, h5::datatype, void *, void *) { return h5::conv_ret::unhandled; });
+  h5::datatype str = H5Tcopy(H5T_C_S1);
+  H5Tset_size(str, 8);
+  std::vector<char> buf(data.size() * 8, '\0');
+  h5::array_interface::array_view rv(str, (void *)buf.data(), 1, false);
+  rv.slab.count[0]   = static_cast<h5::hsize_t>(data.size());
+  rv.parent_shape[0] = static_cast<h5::hsize_t>(data.size());
+
+  try {
+    h5::array_interface::read(f, "ints", rv);
+    FAIL() << "expected an exception for the unconvertible int -> string read";
+  } catch (std::runtime_error const &e) {
+    std::string const msg = e.what();
+    EXPECT_NE(msg.find("int"), std::string::npos);
+    EXPECT_NE(msg.find("std::string"), std::string::npos);
+  }
+}
+
+TEST(H5TypeConv, NativeExceptionForwardsBuffers) {
+  cb_guard guard;
+  h5::file f("type_conv.h5", 'w');
+
+  // fractional doubles -> int truncate: HDF5 delivers a native per-element exception, so the callback must
+  // receive non-null pointers to the source/destination element being converted
+  std::vector<double> data{0.5, 1.5, 2.5};
+  h5::h5_write(f, "fracs", data);
+
+  bool saw_native_buffers = false;
+  h5::set_type_conv_cb([&saw_native_buffers](h5::conv_except e, h5::datatype, h5::datatype, void *src_buf, void *dst_buf) {
+    if (e == h5::conv_except::truncate or e == h5::conv_except::precision) {
+      EXPECT_NE(src_buf, nullptr);
+      EXPECT_NE(dst_buf, nullptr);
+      saw_native_buffers = true;
+    }
+    return h5::conv_ret::unhandled;
+  });
+
+  std::vector<int> out;
+  h5::h5_read(f, "fracs", out);
+  EXPECT_TRUE(saw_native_buffers);
+}
+
+TEST(H5TypeConv, CustomExceptionForwardsNullBuffers) {
+  cb_guard guard;
+  h5::file f("type_conv.h5", 'w');
+
+  // int -> long widening is an h5-specific (custom) not_equal case, raised manually with no per-element buffer,
+  // so the callback must receive null src/dst pointers
+  std::vector<int> data(5);
+  std::iota(data.begin(), data.end(), 0);
+  h5::h5_write(f, "ints", data);
+
+  bool saw_custom = false;
+  h5::set_type_conv_cb([&saw_custom](h5::conv_except e, h5::datatype, h5::datatype, void *src_buf, void *dst_buf) {
+    if (e == h5::conv_except::not_equal or e == h5::conv_except::narrower) {
+      EXPECT_EQ(src_buf, nullptr);
+      EXPECT_EQ(dst_buf, nullptr);
+      saw_custom = true;
+    }
+    return h5::conv_ret::unhandled;
+  });
+
+  std::vector<long> out;
+  h5::h5_read(f, "ints", out);
+  EXPECT_TRUE(saw_custom);
+}


### PR DESCRIPTION
This PR introduces a way to control the currently hard-coded handling of type mismatches between HDF5 files and what is requested on the C++ side,
which will simply print a warning if types are not different.

HDF5 has rich support to customize this behavior via dataset transfer property list and the associated type_conv callback. h5 now maintains a default transfer property list on the library global scope. This transfer property list is passed to every HDF5 read and write call that takes it. Setting a callback is exposed to the user via `h5::set_type_conv_cb`.

The callback closely mirrors what HDF5 does, up to two additional calling conditions `h5::conv_except::not_equal` (types not equal) `h5::conv_except::narrower` (dst type is narrower), for which HDF5 will just handle silently unless the value being read/written will actually not fit in the destination. h5 calls the callback manually for that reason to reproduce the old behavior.

## API Example
```c++
#include <h5/h5.hpp>

// Custom datatype-conversion callback: only fail when a *stored value* cannot be
// represented in the destination type. Merely differing / narrower types are fine
// as long as every value actually fits.
h5::set_type_conv_cb(
   [](h5::conv_except except, h5::datatype src, h5::datatype dst, void *src_buf, void *dst_buf) -> h5::conv_ret {
     switch (except) {
       // Type-level mismatches detected by h5 (no offending element): tolerate them.
       // These come with src_buf == dst_buf == nullptr.
       case h5::conv_except::not_equal:
       case h5::conv_except::narrower:
         return h5::conv_ret::unhandled;   // let HDF5 perform the conversion

       // HDF5's native per-element exceptions: a concrete value can't be represented
       // exactly in `dst` (out of range, precision/truncation loss, non-finite).
       // src_buf / dst_buf point at the offending element.
       case h5::conv_except::range_hi:
       case h5::conv_except::range_low:
       case h5::conv_except::precision:
       case h5::conv_except::truncate:
       case h5::conv_except::pinf:
       case h5::conv_except::ninf:
       case h5::conv_except::nan:
         std::cerr << "value not representable converting "
                   << h5::get_name_of_h5_type(src) << " -> " << h5::get_name_of_h5_type(dst) << "\n";
         return h5::conv_ret::abort;       // h5 turns this into a thrown exception
     }
     return h5::conv_ret::unhandled;
   });
```