### PR TITLE
Deterministic HDF5 group ordering + preserve dict key order in HDFArchive

### DIFF
--- a/c++/h5/group.cpp
+++ b/c++/h5/group.cpp
@@ -191,21 +191,21 @@ namespace h5 {
 
   std::vector<std::string> group::get_all_subgroup_names() const {
     std::vector<std::string> grp_name;
-    int r = H5Literate(::hid_t(id), H5_INDEX_NAME, H5_ITER_NATIVE, nullptr, get_group_elements_name_grp, static_cast<void *>(&grp_name));
+    int r = H5Literate(::hid_t(id), H5_INDEX_NAME, H5_ITER_INC, nullptr, get_group_elements_name_grp, static_cast<void *>(&grp_name));
     if (r != 0) throw std::runtime_error("Error in h5::group: Iterating over subgroups of the group " + name() + "failed");
     return grp_name;
   }
 
   std::vector<std::string> group::get_all_dataset_names() const {
     std::vector<std::string> ds_name;
-    int r = H5Literate(::hid_t(id), H5_INDEX_NAME, H5_ITER_NATIVE, nullptr, get_group_elements_name_ds, static_cast<void *>(&ds_name));
+    int r = H5Literate(::hid_t(id), H5_INDEX_NAME, H5_ITER_INC, nullptr, get_group_elements_name_ds, static_cast<void *>(&ds_name));
     if (r != 0) throw std::runtime_error("Error in h5::group: Iterating over datasets of the group " + name() + "failed");
     return ds_name;
   }
 
   std::vector<std::string> group::get_all_subgroup_dataset_names() const {
     std::vector<std::string> ds_name;
-    int r = H5Literate(::hid_t(id), H5_INDEX_NAME, H5_ITER_NATIVE, nullptr, get_group_elements_name_ds_grp, static_cast<void *>(&ds_name));
+    int r = H5Literate(::hid_t(id), H5_INDEX_NAME, H5_ITER_INC, nullptr, get_group_elements_name_ds_grp, static_cast<void *>(&ds_name));
     if (r != 0) throw std::runtime_error("Error in h5::group: Iterating over datasets and subgroups of the group " + name() + "failed");
     return ds_name;
   }

--- a/c++/h5/group.hpp
+++ b/c++/h5/group.hpp
@@ -176,19 +176,25 @@ namespace h5 {
 
     /**
      * @brief Get all the names of the subgroups in the current group.
-     * @return A vector with the names of all the subgroups.
+     * @return A vector with the names of all the subgroups, in ascending (increasing) name order
+     * (`H5_ITER_INC`). The order is independent of the insertion/native order and stable across
+     * HDF5 versions.
      */
     [[nodiscard]] std::vector<std::string> get_all_subgroup_names() const;
 
     /**
      * @brief Get all the names of the datasets in the current group.
-     * @return A vector with the names of all the datasets.
+     * @return A vector with the names of all the datasets, in ascending (increasing) name order
+     * (`H5_ITER_INC`). The order is independent of the insertion/native order and stable across
+     * HDF5 versions.
      */
     [[nodiscard]] std::vector<std::string> get_all_dataset_names() const;
 
     /**
      * @brief Get all the names of the subgroups and datasets in the current group.
-     * @return A vector with the names of all the subgroups and datasets.
+     * @return A vector with the names of all the subgroups and datasets, in ascending (increasing)
+     * name order (`H5_ITER_INC`). The order is independent of the insertion/native order and stable
+     * across HDF5 versions.
      */
     [[nodiscard]] std::vector<std::string> get_all_subgroup_dataset_names() const;
 

--- a/python/h5/archive.py
+++ b/python/h5/archive.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-import sys,numpy, warnings
+import sys,numpy, warnings, json
 from importlib import import_module
 from .archive_basic_layer import HDFArchiveGroupBasicLayer
 from .formats import register_class, register_backward_compatibility_method, get_format_info
@@ -45,7 +45,10 @@ class Dict:
     def __init__(self,ob) :
         self.ob = ob
     def __reduce_to_dict__(self) :
-        return {str(n):v for n,v in list(self.ob.items())}
+        # Only string keys are supported, Non-string keys are rejected
+        bad = sorted({type(k).__name__ for k in self.ob if not isinstance(k, str)})
+        if bad : raise TypeError("HDFArchive can only store dicts with string keys, found key type(s): %s"%", ".join(bad))
+        return dict(self.ob)
     @classmethod
     def __factory_from_dict__(cls, name, D) :
         return {n:x for n,x in list(D.items())}
@@ -174,12 +177,16 @@ class HDFArchiveGroup(HDFArchiveGroupBasicLayer):
             #SubGroup = HDFArchiveGroup(self,key)
             #write_attributes(SubGroup)
         elif hasattr(val,'__reduce_to_dict__') : # Is it a HDF_compliant object
-            self.create_group(key) # create a new group
             d = val.__reduce_to_dict__()
             if not isinstance(d,dict) : raise ValueError(" __reduce_to_dict__ method does not return a dict. See the doc !")
+            self.create_group(key) # create a new group
             SubGroup = HDFArchiveGroup(self,key)
             for k, v in list(d.items()) : SubGroup[k] = v
             write_attributes(SubGroup)
+            # Preserve the key order of the reduced dict, which HDF5 does not (it
+            # iterates group members by name). This covers plain dicts and any
+            # __factory_from_dict__ class whose reconstruction depends on the order.
+            SubGroup.write_attr('__dict_key_order__', json.dumps(list(d.keys()), ensure_ascii=False))
         elif isinstance(val,numpy.ndarray) : # it is a numpy
             try :
                self._write( key, numpy.array(val,copy=1,order='C') )
@@ -255,10 +262,23 @@ class HDFArchiveGroup(HDFArchiveGroupBasicLayer):
         if hasattr(r_class,"__factory_from_dict__"):
             assert self.is_group(key), "__factory_from_dict__ requires a subgroup"
             reconstruct = lambda k: SubGroup.__getitem1__(k, reconstruct_python_object, fmt_info.backward_compat.get(k, None))
-            values = {k: reconstruct(k) for k in SubGroup}
+            values = {k: reconstruct(k) for k in SubGroup._reconstruction_key_order()}
             return r_class.__factory_from_dict__(key, values)
 
         raise ValueError("Impossible to reread the class %s for group %s and key %s"%(r_class_name,self, key))
+
+    #-------------------------------------------------------------------------
+    def _reconstruction_key_order(self):
+        """Order the keys for python-object reconstruction. Reduced objects store
+        their key order at write time (see __setitem__); when present it must list
+        exactly the group's keys, and we return that order. Absent (older archives,
+        files from other tools) we keep the group's deterministic name order."""
+        order_str = self._group.read_attribute('__dict_key_order__')
+        if not order_str : return list(self.keys())
+        order = json.loads(order_str)
+        if set(order) != set(self.keys()) :
+            raise ValueError("Corrupt archive: __dict_key_order__ %r does not match the group keys %r"%(order, list(self.keys())))
+        return order
 
     #---------------------------------------------------------------------------
     def __str__(self) :

--- a/python/h5/archive.py
+++ b/python/h5/archive.py
@@ -77,6 +77,24 @@ class HDFArchiveGroup(HDFArchiveGroupBasicLayer):
     keys of one HDF5 group. On read, registered Python classes are
     automatically reconstructed via their ``__factory_from_dict__`` (see
     :mod:`h5.formats`); use :meth:`get_raw` to bypass reconstruction.
+
+    Ordering
+    --------
+    Group members are iterated in ascending name order (HDF5 is queried with
+    ``H5_ITER_INC``), which is deterministic and stable across HDF5/Python
+    versions -- unlike the previous native iteration order.
+
+    A ``dict`` (or any object reconstructed via ``__reduce_to_dict__`` /
+    ``__factory_from_dict__`` whose result depends on ordering) round-trips in
+    its original insertion order rather than name order: the key order is
+    recorded in a ``__dict_key_order__`` attribute on write and replayed on
+    read. Archives that lack this attribute (older files, or files written by
+    other tools) fall back to name order. On read the attribute must list
+    exactly the group's keys; a mismatch indicates a corrupt or externally
+    edited archive and raises :class:`ValueError`.
+
+    Only string keys are supported for stored ``dict`` objects; non-string keys
+    raise :class:`TypeError` on write rather than being silently stringified.
     """
     _wrappedType = {
         list : List,

--- a/test/c++/h5_group.cpp
+++ b/test/c++/h5_group.cpp
@@ -74,6 +74,20 @@ TEST(H5, GroupOperations) {
   for (const auto &n : names) { EXPECT_TRUE(n == gname || n == dsname); }
 };
 
+TEST(H5, GroupNameOrdering) {
+  // names should be returned in increasing-name order, independent of insertion order
+  h5::file file("group_order.h5", 'w');
+  h5::group root(file);
+
+  // create subgroups and datasets in a deliberately unsorted insertion order
+  for (const auto &n : {"gc", "ga", "gb"}) std::ignore = root.create_group(n);
+  for (const auto &n : {"dz", "dx", "dy"}) h5::write(root, n, 0);
+
+  EXPECT_EQ(root.get_all_subgroup_names(), (std::vector<std::string>{"ga", "gb", "gc"}));
+  EXPECT_EQ(root.get_all_dataset_names(), (std::vector<std::string>{"dx", "dy", "dz"}));
+  EXPECT_EQ(root.get_all_subgroup_dataset_names(), (std::vector<std::string>{"dx", "dy", "dz", "ga", "gb", "gc"}));
+}
+
 TEST(H5, GroupWriteRead) {
   // test writing/reading datasets in groups
   {

--- a/test/python/archive.py
+++ b/test/python/archive.py
@@ -17,6 +17,21 @@ import numpy as np
 from math import isnan
 
 from h5 import HDFArchive
+from h5.formats import register_class
+
+class OrderReliantReduce:
+    """A __reduce_to_dict__/__factory_from_dict__ class (not a plain dict) whose
+    reconstruction depends on the stored key order, used to check that key
+    ordering is preserved for any reduce-based type, not only dict."""
+    def __init__(self, order):
+        self.order = list(order)
+    def __reduce_to_dict__(self):
+        return {k: i for i, k in enumerate(self.order)}
+    @classmethod
+    def __factory_from_dict__(cls, name, D):
+        return cls(D.keys())
+
+register_class(OrderReliantReduce)
 
 def assert_arrays_are_close(a, b, precision = 1.e-6):
     d = np.amax(np.abs(a - b))
@@ -184,6 +199,82 @@ class TestHdf5Io(unittest.TestCase):
         with HDFArchive(filename, 'a') as a:
             with self.assertRaises(RuntimeError) :
                 a.create_softlink('data', 'link', delete_if_exists = False)
+
+    def _assert_dict_restored(self, actual, expected):
+        """Fail unless `actual` reproduces `expected` exactly: identical key
+        order, identical key types, and identical value types/values
+        (recursing into nested dicts, comparing arrays elementwise)."""
+        self.assertIsInstance(actual, dict)
+        # 1. same ordering (and same key values)
+        self.assertEqual(list(actual.keys()), list(expected.keys()))
+        # 2. same key types
+        for ka, ke in zip(actual.keys(), expected.keys()):
+            self.assertIs(type(ka), type(ke), "key %r vs %r: type mismatch"%(ka, ke))
+        # 3. same value types/values
+        for k in expected:
+            va, ve = actual[k], expected[k]
+            if isinstance(ve, np.ndarray):
+                self.assertIsInstance(va, np.ndarray)
+                assert_arrays_are_close(va, ve)
+            elif isinstance(ve, dict):
+                self._assert_dict_restored(va, ve)
+            else:
+                self.assertIs(type(va), type(ve), "value for key %r: type mismatch"%(k,))
+                self.assertEqual(va, ve)
+
+    def _roundtrip(self, filename, obj):
+        with HDFArchive(filename, 'w') as a:
+            a['d'] = obj
+        with HDFArchive(filename, 'r') as a:
+            return a['d']
+
+    def test_dict_ordering(self):
+        # insertion order differs from lexicographic order
+        d = {'c': 1, 'a': 2, 'b': 3, 'delta': 4}
+        self.assertNotEqual(list(d.keys()), sorted(d.keys()))
+        self._assert_dict_restored(self._roundtrip('h5_dict_ordering.h5', d), d)
+
+    def test_dict_value_types(self):
+        # heterogeneous value types under (deliberately unsorted) string keys
+        d = {
+            'i': 5,
+            'f': 2.5,
+            's': 'text',
+            'b': True,
+            'lst': [1, 'a', 2.5],
+            'nested': {'x': 1, 'y': 2},
+            'arr': np.array([1.0, 2.0, 3.0]),
+        }
+        self._assert_dict_restored(self._roundtrip('h5_dict_valtypes.h5', d), d)
+
+    def test_dict_nested_ordering(self):
+        # order must be preserved recursively for nested dicts
+        d = {'z': {'q': 1, 'a': 2}, 'y': 3, 'x': {'m': 4, 'b': 5}}
+        self._assert_dict_restored(self._roundtrip('h5_dict_nested.h5', d), d)
+
+    def test_reduce_class_key_order(self):
+        # key order is preserved for any __reduce_to_dict__ class, not only dict
+        obj = OrderReliantReduce(['z', 'a', 'm', 'b'])
+        r = self._roundtrip('h5_reduce_order.h5', obj)
+        self.assertIsInstance(r, OrderReliantReduce)
+        self.assertEqual(r.order, obj.order)
+
+    def test_dict_non_string_keys_raise(self):
+        # Dict storage is limited to string keys: non-string keys must fail
+        # loudly rather than be silently stringified (which loses the key type
+        # and collapses collisions like 1 vs '1').
+        bad = [
+            {1: 'a'},              # int
+            {1.5: 'a'},            # float
+            {(1, 2): 'a'},         # tuple
+            {None: 'a'},           # None
+            {True: 'a'},           # bool
+            {'ok': 1, 2: 'b'},     # mixed string + non-string
+        ]
+        for d in bad:
+            with HDFArchive('h5_dict_badkeys.h5', 'w') as a:
+                with self.assertRaises(TypeError):
+                    a['d'] = d
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make group-member and dict-key ordering reproducible when reading HDF5 archives.

**C++** — `group::get_all_subgroup_names`, `get_all_dataset_names`, and `get_all_subgroup_dataset_names` now iterate with `H5_ITER_INC` (increasing name order) instead of `H5_ITER_NATIVE` (backend-dependent, unstable across files/versions).

**Python (`HDFArchive`)** — HDF5 iterates members by name, so a `dict` round-tripped through an archive came back in lexicographic rather than insertion order. On write we now store the reduced object's key order in a `__dict_key_order__` attribute and replay it on read; this also covers any `__reduce_to_dict__`/`__factory_from_dict__` class whose reconstruction depends on order. On read the attribute must list exactly the group's keys — a mismatch means a corrupt/externally-edited archive and raises `ValueError`. Archives without the attribute (older files, other tools) fall back to name order.

Also: `Dict.__reduce_to_dict__` now raises `TypeError` on non-string keys instead of silently stringifying them (which lost the key type and could collapse `1` vs `'1'`).

## Tests
- `h5_group.cpp`: the three accessors return names in increasing order regardless of insertion order.
- `archive.py`: dict key-order round-trip (flat + nested), heterogeneous value types, order preservation for a non-dict reduce class, and non-string keys raising `TypeError`.
